### PR TITLE
Corrigindo um erro de ajuste de conteúdo na tela inicial.

### DIFF
--- a/Assets/CSS/Home.css
+++ b/Assets/CSS/Home.css
@@ -86,6 +86,12 @@
 
 @media (max-width: 767px) {
 
+    #container main {
+
+        flex-wrap: nowrap;
+    
+    }
+
     #container main figure {
 
         height: 200px;

--- a/Assets/CSS/Index.css
+++ b/Assets/CSS/Index.css
@@ -26,7 +26,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: flex-start;
+    justify-content: center;
     overflow: hidden;
 
 }
@@ -46,7 +46,7 @@ body {
     position: relative;
     display: flex;
     align-items: center;
-    justify-content: space-evenly;
+    justify-content: center;
     overflow-x: hidden;
     overflow-y: auto;
 


### PR DESCRIPTION
A propriedade wrap do flexbox estava fazendo com que um conteúdo vertical ficasse na horizontal, não cabendo na tela.